### PR TITLE
Fix vulnerable urllib3 package.

### DIFF
--- a/requirements-third-party.txt
+++ b/requirements-third-party.txt
@@ -8,4 +8,4 @@ pyOpenSSL==24.2.1
 requests==2.32.3
 setuptools
 six==1.17.0
-urllib3==2.6.1
+urllib3==2.6.3


### PR DESCRIPTION
Fix vulnerable urllib3 package.

Upgrade to latest version to address vulnerabilities in urllib3 package.
https://github.com/advisories/GHSA-38jv-5279-wg99